### PR TITLE
Add children setter

### DIFF
--- a/lib/src/view/Section.dart
+++ b/lib/src/view/Section.dart
@@ -16,7 +16,7 @@ class Section extends View implements IDSpace {
   /** Returns the SECTION element.
    */
   @override
-  Element render_() => new Element.tag("section");
+  Element render_() => new Element.section();
   @override
   String get className => "Section";
 }

--- a/lib/src/view/View.dart
+++ b/lib/src/view/View.dart
@@ -974,6 +974,25 @@ class View implements StreamTarget<ViewEvent> {
       _layout = new LayoutDeclaration(this);
     return _layout;
   }
+  
+  setLayout({
+    String type, 
+    String orientation, 
+    String align,
+    String spacing,
+    String gap,
+    String width,
+    String height
+    }) {
+    _layout = new LayoutDeclaration(this)
+      ..type = type
+      ..orient = orientation
+      ..align = align
+      ..spacing = spacing
+      ..gap = gap
+      ..width = width
+      ..height = height;
+  }
   /** Returns the profile, i.e., the layout requirement, of this view.
    * It provides additional information for the parent view to
    * layout this view.

--- a/lib/src/view/View.dart
+++ b/lib/src/view/View.dart
@@ -223,6 +223,13 @@ class View implements StreamTarget<ViewEvent> {
       _children = new _SubviewList(this);
     return _children;
   }
+  /**
+   * Sets the list of children
+   */
+  set children(List<View> children) {
+    this.children.clear();
+    children.forEach((child) => this.addChild(child));
+  }
   /** Returns the number of child views.
    */
   int get childCount => _childInfo != null ? _childInfo.nChild: 0;

--- a/test/TestSetChildren.dart
+++ b/test/TestSetChildren.dart
@@ -1,0 +1,21 @@
+import 'package:rikulo_ui/view.dart';
+
+void main() {
+  new View()
+    ..layout.type = "linear"
+    ..layout.orient = "vertical"
+    ..children = [
+      new TextView("Hello World!")
+        ..on.click.listen((event) {
+          (event.target as TextView).text = "Welcome to Rikulo.";
+          event.target.requestLayout();
+        }),
+      new View()
+        ..layout.type = "linear" //arrange the layout of child views linearly
+        ..children = [
+            new TextView("Name"), //a label
+            new TextBox()
+          ]
+        ]
+    ..addToDocument(); 
+}

--- a/test/TestSetChildren.html
+++ b/test/TestSetChildren.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <link rel="stylesheet" type="text/css" href="packages/rikulo_ui/css/default/view.css" />
+  </head>
+  <body>
+    <script type="application/dart" src="TestSetChildren.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
It would be shorter to have a children setter instead the addChild Method, for example instead of:

```
void main() {
  new View()
    ..addChild(new TextView("Hello World!")
    ..on.click.listen((event) {
      (event.target as TextView).text = "Welcome to Rikulo.";
      event.target.requestLayout();
    }), new TextView("Hello World!"))
    ..addChild(new View()
      ..layout.type = "linear" //arrange the layout of child views linearly
      ..addChild(new TextView("Name")) //a label
      ..addChild(new TextBox()))
    ..addToDocument(); 

}
```

would be shorter to have:

```
new View()
    ..children = [
      new TextView("Hello World!")
        ..on.click.listen((event) {
          (event.target as TextView).text = "Welcome to Rikulo.";
          event.target.requestLayout();
      }),
      new View()
        ..layout.type = "linear" //arrange the layout of child views linearly
        ..children = [
          new TextView("Name"), //a label
          new TextBox()
      ]
   ]
   ..addToDocument(); 
```

I think that it could be solved adding this code to the View class:
